### PR TITLE
Getkube

### DIFF
--- a/hello_apache.sh
+++ b/hello_apache.sh
@@ -13,13 +13,13 @@ EOF
 echo "Running projectatomic/helloapache"
 atomic run projectatomic/helloapache
 
-helloapache
-
 #echo "Checking kubernetes pod"
 #kubectl get pod helloapache
 
-#echo "Running curl"
-#curl http://localhost/
+# we might need to wait bit, for the app to be running
+sleep 60
+echo "Running curl"
+curl http://localhost/
 
 echo "Exiting"
 exit 0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -40,7 +40,7 @@ systemctl daemon-reload
 rtn_code=0
 for serv in docker etcd kube-apiserver kube-controller-manager kube-scheduler kubelet kube-proxy; do
   service $serv start 
-  rtn=$? ; if [ $rtn -gt $rtn_code]; then rtn_code=$rtn ; fi
+  rtn=$? ; if [ $rtn -gt $rtn_code ]; then rtn_code=$rtn ; fi
 done
 
 if [ $rtn_code -eq 0 ]; then


### PR DESCRIPTION
fix a syntax issue; just hit curl once the app is running. docker seems to be downloading the app and its deps to run them fine,

I've done this with a sleep, but it might be better to wait for kubectl to report success/fail
